### PR TITLE
Implement FormlessParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ And for Nginx:
         [host] => "hotelpublisher.com"
     )
 
+Otherwise you can use the FormlessParser for formless log files:
+
+    stdClass Object (
+        [type] => "info"
+        [message] => "23263#0: *1 directory index of "/var/www/ssl/" is forbidden, client: 86.186.86.232, server: hotelpublisher.com, request: "GET / HTTP/1.1", host: "hotelpublisher.com""
+    )
 ## Contributing
 
 Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for information on how to contribute.

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -6,6 +6,7 @@ use TM\ErrorLogParser\Exception\UnknownTypeException;
 use TM\ErrorLogParser\Exception\FormatException;
 use TM\ErrorLogParser\Parser\AbstractParser;
 use TM\ErrorLogParser\Parser\ApacheParser;
+use TM\ErrorLogParser\Parser\FormlessParser;
 use TM\ErrorLogParser\Parser\NginxParser;
 
 /**
@@ -17,6 +18,7 @@ class Parser
 {
     const TYPE_APACHE = 'apache';
     const TYPE_NGINX  = 'nginx';
+    const TYPE_FORMLESS  = 'formless';
 
     /**
      * @var AbstractParser
@@ -37,6 +39,10 @@ class Parser
 
         if (self::TYPE_NGINX === $type) {
             $this->parser = new NginxParser;
+        }
+
+        if (self::TYPE_FORMLESS === $type) {
+            $this->parser = new FormlessParser();
         }
 
         if (!$this->parser instanceof AbstractParser) {

--- a/src/Parser/FormlessParser.php
+++ b/src/Parser/FormlessParser.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace TM\ErrorLogParser\Parser;
+
+use TM\ErrorLogParser\Parser\AbstractParser;
+
+/**
+ * Class Parser
+ *
+ * @package TM\ErrorLogParser
+ */
+class FormlessParser extends AbstractParser
+{
+    /**
+     * @param string $line
+     *
+     * @return \stdClass
+     */
+    public function parse($line)
+    {
+        $object = new \stdClass();
+
+        $object->type = 'info';
+        $object->message = $line;
+
+        return $object;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPatterns()
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/formless_error.log
+++ b/tests/Fixtures/formless_error.log
@@ -1,0 +1,1 @@
+23263#0: *1 directory index of "/var/www/ssl/" is forbidden, client: 86.186.86.232, server: hotelpublisher.com, request: "GET / HTTP/1.1", host: "hotelpublisher.com"

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -33,6 +33,22 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider getValidFormlessLogFiles
+     *
+     * @param string $logfile
+     */
+    public function testCanParseAFormlessErrorLogLine($logfile)
+    {
+        $parser = new Parser(Parser::TYPE_FORMLESS);
+        $lines = file($logfile);
+
+        $object = $parser->parse(current($lines));
+
+        $this->assertEquals('info', $object->type);
+        $this->assertNotNull($object->message);
+    }
+
+    /**
      * @dataProvider getInvalidApacheLogFiles
      * @expectedException \TM\ErrorLogParser\Exception\FormatException
      * @expectedExceptionMessageRegExp /The parser only supports the default Log-Format/
@@ -71,6 +87,16 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [__DIR__ . '/Fixtures/nginx_valid_error.log'],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getValidFormlessLogFiles()
+    {
+        return [
+            [__DIR__ . '/Fixtures/formless_error.log'],
         ];
     }
 


### PR DESCRIPTION
Hey tommy-muehle,

in my case i have formless log files. Your parsers expect a strict line structure so i implemented a "FormlessParser". Now you're able to parse log files like this:

```
[10-07-2016] Cronjob "handleOrders" started
[10-07-2016] Cronjob "handleOrders" failed cause .... 
```

kind regards,
ukrator
