### PR TITLE
Add invalid parser type exception test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 php:
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
   - nightly
   - hhvm
 matrix:
@@ -12,7 +16,7 @@ matrix:
 before_install:
   - composer self-update
 install:
-  - composer install --no-interaction --prefer-source
+  - composer install --no-interaction --prefer-dist
 script:
   - vendor/bin/phpunit
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=5.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.*"
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-4": {

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -3,13 +3,15 @@
 namespace TM\ErrorLogParser\Tests;
 
 use TM\ErrorLogParser\Parser;
+use PHPUnit\Framework\TestCase;
+use TM\ErrorLogParser\Exception\UnknownTypeException;
 
 /**
  * Class ParserTest
  *
  * @package TM\ErrorLogParser\Tests\Apache
  */
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
     /**
      * @dataProvider getValidApacheLogFiles
@@ -73,6 +75,13 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('error', $object->type);
         $this->assertEquals('86.186.86.232', $object->client);
         $this->assertEquals('hotelpublisher.com', $object->server);
+    }
+
+    public function testThrowUnknownTypeExceptionOnInvalidParserType()
+    {
+        $this->setExpectedException(UnknownTypeException::class);
+
+        new Parser('UnknownParserType');
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Add `php-7.1`, `php-7.2`, `php-7.3` and `php-7.4` version tests on Travis CI build.
- Using the `--prefer-dist` to install stable dependencies during `composer install` command.
- Using the `PHPUnit ^5.7` version definition.
- Using the `PHPUnit\Framework\TestCase` namesapce.
- Add `testThrowUnknownTypeExceptionOnInvalidParserType` to have the test about throwing exception on invalid parser type.